### PR TITLE
 feat: add client chat metadata support with external platform tracking

### DIFF
--- a/docs/systems/communications.md
+++ b/docs/systems/communications.md
@@ -28,7 +28,7 @@ Key fields:
 - `recipient_email`: External recipient
 - `direction`: 'INBOUND' | 'OUTBOUND'
 - `status`: 'SENT' | 'DELIVERED' | 'READ' | 'BOUNCED' | 'FAILED'
-- `communication_type`: 'email' | 'sms' | 'phone_call'
+- `communication_type`: 'email' | 'phone' | 'sms' | 'client_chat'
 - `subject` / `body`: Email content
 - `metadata`: Additional context (attachments, etc.)
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -118,6 +118,8 @@ export {
   CommunicationTypeSchema,
   EmailDirectionSchema,
   EmailStatusSchema,
+  ClientChatStatusSchema,
+  ExternalPlatformTypeSchema,
   CallDirectionSchema
 } from './schemas/communications';
 
@@ -132,6 +134,8 @@ export type {
   CommunicationType,
   EmailDirection,
   EmailStatus,
+  ClientChatStatus,
+  ExternalPlatformType,
   CallDirection
 } from './schemas/communications';
 

--- a/serverless-api/src/schemas/openapi/components.ts
+++ b/serverless-api/src/schemas/openapi/components.ts
@@ -390,7 +390,7 @@ export const openApiComponents = {
         body: { type: 'string', nullable: true },
         communication_type: {
           type: 'string',
-          enum: ['email', 'phone', 'sms', 'internal_note'],
+          enum: ['email', 'phone', 'sms', 'client_chat'],
           description: 'Type of communication'
         },
         direction: {
@@ -448,7 +448,7 @@ export const openApiComponents = {
         body: { type: 'string', minLength: 1 },
         communication_type: {
           type: 'string',
-          enum: ['email', 'phone', 'sms', 'internal_note']
+          enum: ['email', 'phone', 'sms', 'client_chat']
         },
         direction: {
           type: 'string',

--- a/serverless-api/src/schemas/openapi/paths.ts
+++ b/serverless-api/src/schemas/openapi/paths.ts
@@ -576,7 +576,7 @@ export const openApiPaths = {
         {
           name: 'communication_type',
           in: 'query',
-          schema: { type: 'string', enum: ['email', 'phone', 'sms', 'internal_note'] },
+          schema: { type: 'string', enum: ['email', 'phone', 'sms', 'client_chat'] },
           description: 'Filter by communication type'
         },
         {
@@ -588,8 +588,8 @@ export const openApiPaths = {
         {
           name: 'status',
           in: 'query',
-          schema: { type: 'string', enum: ['SENT', 'DELIVERED', 'READ', 'BOUNCED', 'FAILED'] },
-          description: 'Filter by status'
+          schema: { type: 'string', enum: ['DRAFT', 'SENT', 'DELIVERED', 'READ', 'BOUNCED', 'FAILED'] },
+          description: 'Filter by status (includes client chat status values)'
         },
         {
           name: 'page',
@@ -607,7 +607,7 @@ export const openApiPaths = {
           name: 'include',
           in: 'query',
           schema: { type: 'string' },
-          description: 'Comma-separated list of related data to include (email_metadata, phone_metadata, sender, workflow)'
+          description: 'Comma-separated list of related data to include (email_metadata, phone_metadata, client_chat_metadata, sender, workflow)'
         }
       ],
       responses: {
@@ -752,7 +752,7 @@ export const openApiPaths = {
               properties: {
                 status: {
                   type: 'string',
-                  enum: ['SENT', 'DELIVERED', 'READ', 'BOUNCED', 'FAILED']
+                  enum: ['DRAFT', 'SENT', 'DELIVERED', 'READ', 'BOUNCED', 'FAILED']
                 },
                 metadata: { type: 'object' }
               }

--- a/supabase/migrations/20250728000000_add_client_chat_metadata.sql
+++ b/supabase/migrations/20250728000000_add_client_chat_metadata.sql
@@ -1,0 +1,39 @@
+-- =====================================================
+-- Add Client Chat Metadata Support
+-- Migration to add client_chat_metadata table and 
+-- update communication status enum for client chat
+-- =====================================================
+
+-- Add client chat status to enum
+ALTER TYPE email_status ADD VALUE IF NOT EXISTS 'DRAFT';
+
+-- Add external platform type enum for client chat metadata
+CREATE TYPE external_platform_type AS ENUM ('qualia', 'gridbase', 'salesforce', 'custom');
+
+-- Create client chat metadata table
+CREATE TABLE client_chat_metadata (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    communication_id UUID NOT NULL REFERENCES communications(id) ON DELETE CASCADE,
+    external_platform_type external_platform_type,
+    external_platform_id TEXT,
+    cc_recipients TEXT[], -- Will store email addresses
+    bcc_recipients TEXT[], -- Will store email addresses
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    
+    UNIQUE(communication_id)
+);
+
+-- Add index for performance
+CREATE INDEX idx_client_chat_metadata_communication ON client_chat_metadata(communication_id);
+CREATE INDEX idx_client_chat_metadata_platform_type ON client_chat_metadata(external_platform_type);
+CREATE INDEX idx_client_chat_metadata_platform_id ON client_chat_metadata(external_platform_id);
+
+-- Add trigger for updated_at if we decide to add it later
+-- For now, just created_at as per the schema design
+
+-- Add table comment
+COMMENT ON TABLE client_chat_metadata IS 'Metadata specific to client chat communications, including external platform tracking and additional recipients';
+COMMENT ON COLUMN client_chat_metadata.external_platform_type IS 'External platform type (qualia, gridbase, salesforce, custom)';
+COMMENT ON COLUMN client_chat_metadata.external_platform_id IS 'External platform-specific identifier for this communication';
+COMMENT ON COLUMN client_chat_metadata.cc_recipients IS 'Array of email addresses to CC on client chat communications';
+COMMENT ON COLUMN client_chat_metadata.bcc_recipients IS 'Array of email addresses to BCC on client chat communications';


### PR DESCRIPTION
  - Add client_chat_metadata table with external platform integration
  - Extend communication status enum to include DRAFT for client chats
  - Add ExternalPlatformTypeSchema (qualia, gridbase, salesforce, custom)
  - Support cc/bcc recipients with email validation