### PR TITLE
 feat: add file upload support to document versions endpoint 

### DIFF
--- a/frontend/src/lib/hooks/use-documents.ts
+++ b/frontend/src/lib/hooks/use-documents.ts
@@ -143,11 +143,38 @@ export function useDocumentMutations() {
     },
   });
 
+  const createVersionWithFile = useMutation({
+    mutationFn: ({ id, file, changeSummary, metadata }: { 
+      id: string; 
+      file: File; 
+      changeSummary: string; 
+      metadata?: object 
+    }) => api.documents.createVersionWithFile(id, file, changeSummary, metadata),
+    onSuccess: (updatedDocument) => {
+      // Update the specific document in cache
+      queryClient.setQueryData(
+        documentKeys.detail(updatedDocument.id), 
+        updatedDocument
+      );
+
+      // Invalidate lists to refresh version info
+      queryClient.invalidateQueries({ queryKey: documentKeys.lists() });
+      
+      // Invalidate workflow-specific documents
+      if (updatedDocument.workflow_id) {
+        queryClient.invalidateQueries({ 
+          queryKey: documentKeys.byWorkflow(updatedDocument.workflow_id) 
+        });
+      }
+    },
+  });
+
   return {
     createDocument,
     updateDocument,
     deleteDocument,
     createVersion,
+    createVersionWithFile,
   };
 }
 

--- a/packages/shared/src/schemas/documents.ts
+++ b/packages/shared/src/schemas/documents.ts
@@ -87,6 +87,12 @@ export const CreateDocumentVersionSchema = z.object({
   metadata: z.record(z.any()).default({}),
 });
 
+// Create document version with file upload schema (for FormData requests)
+export const CreateDocumentVersionWithFileSchema = z.object({
+  change_summary: z.string().min(1, 'Change summary is required'),
+  metadata: z.string().optional().transform(val => val ? JSON.parse(val) : {}),
+});
+
 // Document with related data (for responses with includes)
 export const DocumentWithRelationsSchema = DocumentSchema.extend({
   workflow: z.object({
@@ -112,6 +118,7 @@ export type CreateDocument = z.infer<typeof CreateDocumentSchema>;
 export type UpdateDocument = z.infer<typeof UpdateDocumentSchema>;
 export type DocumentFilters = z.infer<typeof DocumentFiltersSchema>;
 export type CreateDocumentVersion = z.infer<typeof CreateDocumentVersionSchema>;
+export type CreateDocumentVersionWithFile = z.infer<typeof CreateDocumentVersionWithFileSchema>;
 export type DocumentWithRelations = z.infer<typeof DocumentWithRelationsSchema>;
 
 // Export document types and status enums

--- a/serverless-api/src/schemas/openapi/paths.ts
+++ b/serverless-api/src/schemas/openapi/paths.ts
@@ -1088,7 +1088,7 @@ export const openApiPaths = {
     post: {
       tags: ['Documents'],
       summary: 'Create document version',
-      description: 'Create a new version of an existing document',
+      description: 'Create a new version of an existing document. Supports both JSON (URL-based) and FormData (file upload) requests.',
       parameters: [
         {
           name: 'id',
@@ -1102,7 +1102,42 @@ export const openApiPaths = {
         required: true,
         content: {
           'application/json': {
-            schema: { $ref: '#/components/schemas/CreateDocumentVersion' }
+            schema: { $ref: '#/components/schemas/CreateDocumentVersion' },
+            example: {
+              url: 'https://storage.example.com/documents/updated-document.pdf',
+              filename: 'updated-document.pdf',
+              change_summary: 'Updated with corrections',
+              metadata: {
+                revision_notes: 'Fixed formatting issues'
+              }
+            }
+          },
+          'multipart/form-data': {
+            schema: {
+              type: 'object',
+              required: ['file', 'change_summary'],
+              properties: {
+                file: {
+                  type: 'string',
+                  format: 'binary',
+                  description: 'The new file to upload'
+                },
+                change_summary: {
+                  type: 'string',
+                  minLength: 1,
+                  description: 'Description of changes in this version'
+                },
+                metadata: {
+                  type: 'string',
+                  description: 'JSON string of additional metadata'
+                }
+              }
+            },
+            example: {
+              file: '(binary file data)',
+              change_summary: 'OCR processing applied',
+              metadata: '{"ocr_processed": true, "confidence_score": 0.95}'
+            }
           }
         }
       },
@@ -1116,6 +1151,35 @@ export const openApiPaths = {
                 properties: {
                   success: { type: 'boolean', example: true },
                   data: { $ref: '#/components/schemas/Document' }
+                }
+              }
+            }
+          }
+        },
+        '400': {
+          description: 'Invalid request data',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  success: { type: 'boolean', example: false },
+                  error: { type: 'string' },
+                  details: { type: 'array', items: { type: 'object' } }
+                }
+              }
+            }
+          }
+        },
+        '404': {
+          description: 'Document not found or access denied',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  success: { type: 'boolean', example: false },
+                  error: { type: 'string', example: 'Document not found or access denied' }
                 }
               }
             }


### PR DESCRIPTION
 ## Summary
  Add file upload capability to document versions endpoint while maintaining backward compatibility. Enables OCR workflows to upload processed files as new versions without changing document IDs.

  ## Changes
  - **Backend**: Enhanced `POST /api/documents/:id/versions` to handle both JSON and FormData requests
  - **Frontend**: Added `createVersionWithFile` method alongside existing `createVersion`
  - **Schemas**: Added `CreateDocumentVersionWithFileSchema` for FormData validation
  - **Docs**: Updated OpenAPI spec with multipart/form-data support

  ## Usage
  ```bash
  # New: File upload
  curl -X POST "/api/documents/{id}/versions" \
    -F "file=@ocr-processed.pdf" \
    -F "change_summary=OCR processing applied"

  # Existing: JSON (unchanged)
  curl -X POST "/api/documents/{id}/versions" \
    -H "Content-Type: application/json" \
    -d '{"url": "...", "change_summary": "..."}'
```
  Benefits

  - Same document ID preserves relationships
  - Version history with file preservation
  - Automatic error handling with cleanup
  - Full backward compatibility